### PR TITLE
Fixed issue with create connecton API call - missing Content-Type header

### DIFF
--- a/utilities/Token.go
+++ b/utilities/Token.go
@@ -24,7 +24,7 @@ func GetToken(apiKey, apiVersion string) (*Token, *errors.APIError) {
 	body, _, err := NewAPI("https://au-api.basiq.io/").SetHeader("Authorization", "Basic "+apiKey).
 		SetHeader("basiq-version", apiVersion).
 		SetHeader("content-type", "application/json").
-		Send("POST", "oauth2/token", nil)
+		Send("POST", "token", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/ConnectionService.go
+++ b/v2/ConnectionService.go
@@ -79,6 +79,7 @@ func (cs *ConnectionService) NewConnection(connectionData *ConnectionData) (Job,
 		return data, &errors.APIError{Message: errorr.Error()}
 	}
 
+	cs.Session.Api.SetHeader("Content-Type", "application/json")
 	body, _, err := cs.Session.Api.Send("POST", "users/"+cs.user.Id+"/connections", jsonBody)
 	if err != nil {
 		return data, err


### PR DESCRIPTION
Create connection call is failing because of missing content-type header.
Please note that token endpoint is also changed with this commit, from '/oauth2/token' to '/token' (as '/token' endpoint is used in API documentation): https://api.basiq.io/v2.0/reference#authentication  and https://api.basiq.io/v1.0/reference#authentication